### PR TITLE
Fix AttributeError: module 'sphinx' has no attribute 'application'

### DIFF
--- a/src/sphinx_basic_ng/__init__.py
+++ b/src/sphinx_basic_ng/__init__.py
@@ -5,12 +5,12 @@ __version__ = "0.0.1.dev11"
 from pathlib import Path
 from typing import Any, Dict
 
-import sphinx
+from sphinx.application import Sphinx
 
 _THEME_PATH = (Path(__file__).parent / "theme" / "basic-ng").resolve()
 
 
-def setup(app: sphinx.application.Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> Dict[str, Any]:
     """Entry point for sphinx theming."""
     app.require_sphinx("3.0")
 


### PR DESCRIPTION
When trying to import sphinx_basic_ng I get the following error message:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/lib/python3.9/site-packages/sphinx_basic_ng/__init__.py", line 13, in <module>
    def setup(app: sphinx.application.Sphinx) -> Dict[str, Any]:
AttributeError: module 'sphinx' has no attribute 'application'
```
I got this error message while trying to package sphinx-basic-ng for Nixpkgs, since furo now depends on it. When packaging a python package in Nixpkgs it is common to have a basic test that just attempts to import the module to see if at least this basic functionality works.
I don't know why nobody else seems to have experienced this error.
Replacing `import sphinx` with `import sphinx.application` would also fix the error but I think the change in this commit makes the intent more explicit.
I realise that I had [the same problem with furo](https://github.com/pradyunsg/furo/discussions/197) before, where the error was (accidentally?) fixed in https://github.com/pradyunsg/furo/commit/d467db25edc515bd240fd13e803d6a617a7412f1 by replacing `import sphinx` with `import sphinx.application`, so everything started working after an update. But furo also contains the variant I decided on using here: https://github.com/pradyunsg/furo/blob/2969c2300aef17a72424007b67ea243a897e40bc/src/furo/sphinxext.py#L22.