### PR TITLE
Add source_provider setting for edit link (#35 proposal)

### DIFF
--- a/src/sphinx_basic_ng/theme/basic-ng/components/edit-this-page.html
+++ b/src/sphinx_basic_ng/theme/basic-ng/components/edit-this-page.html
@@ -5,6 +5,27 @@
   {%- set repo = sanitise_trailing_slash(theme_source_repository) -%}
   {%- set branch = theme_source_branch -%}
   {%- set subdirectory = sanitise_trailing_slash(theme_source_directory) -%}
+  {%- set provider = theme_source_provider -%}
+  
+  {%- if not provider -%}
+    {#- Don't allow http:// URLs -#}
+    {%- if repo.startswith(
+      (
+        "http://github.com/",
+        "http://gitlab.com/",
+        "http://bitbucket.org/",
+      )
+    ) -%}
+      {{ warning("Could not use `source_repository` provided. Please use https:// links in your `conf.py` file's `html_theme_options`.") }}
+    {#- Handle the relevant cases -#}
+    {%- elif repo.startswith("https://github.com/") -%}
+      {%- set provider = "github" -%}
+    {%- elif repo.startswith("https://gitlab.com/") -%}
+      {%- set provider = "gitlab" -%}
+    {%- elif repo.startswith("https://bitbucket.org/") -%}
+      {%- set provider = "bitbucket" -%}
+    {%- endif -%}
+  {%- endif -%}
 
   {#- Figure out the document's source file path. -#}
   {%- set relative_path = pagename + page_source_suffix -%}
@@ -13,26 +34,16 @@
   {%- else -%}
     {%- set document_path = subdirectory + "/" + relative_path -%}
   {%- endif -%}
-
-  {#- Don't allow http:// URLs -#}
-  {%- if repo.startswith(
-    (
-      "http://github.com/",
-      "http://gitlab.com/",
-      "http://bitbucket.org/",
-    )
-  ) -%}
-    {{ warning("Could not use `source_repository` provided. Please use https:// links in your `conf.py` file's `html_theme_options`.") }}
-  {#- Handle the relevant cases -#}
-  {%- elif repo.startswith("https://github.com/") -%}
+  
+  {%- if provider == "github" -%}
     {{ repo }}/edit/{{ branch }}/{{ document_path }}
-  {%- elif repo.startswith("https://gitlab.com/") -%}
+  {%- elif provider == "gitlab" -%}
     {{ repo }}/-/edit/{{ branch }}/{{ document_path }}
-  {%- elif repo.startswith("https://bitbucket.org/") -%}
+  {%- elif provider == "bitbucket" -%}
     {{ repo }}/src/{{ branch }}/{{ document_path }}?mode=edit&at={{ branch }}
   {#- Fail with a warning -#}
   {%- else -%}
-    {{ warning("Could not understand `source_repository` provided: " + repo) }}
+    {{ warning("`source_provider` <" + provider + "> not known and cannot be extracted from `source_repository` provided: " + repo) }}
   {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
This patch allow to use `source_provider` to handle the case where `source_directory` is not a well-known url (https://gitlab.com, https://github.com, https://bitbucket.org).

This patch implies that project using spinx_basic_ng update their `theme.conf` file to add a `source_directory =` default setting (else this patch trigger errors at runtime). Not sure if it is possible and/or desired to handle the case where `theme.conf` is not updated.